### PR TITLE
fix release regex

### DIFF
--- a/merge/README.md
+++ b/merge/README.md
@@ -24,9 +24,9 @@
 
 - If we’re on master:
     - Open PRs with changes from head branch master onto base branches matching:
-        - '^release/\d{4}$'
+        - 'release/\d{4}$'
         - 'hotfix/.*'
-- If we’re on a branch matching '^release/\d{4}$':
+- If we’re on a branch matching 'release/\d{4}$':
     - Open PRs from each release branch to develop
 - If we’re on develop:
     - Open PRs with changes from head branch develop onto base branches matching 'sprint/.*'

--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -98,7 +98,7 @@ if [ "${GITHUB_REF}" == "refs/heads/master" ]; then
     # create PR from master => develop
     open_and_merge_pull_request develop;
     # create PRs from master => release branches
-    for branch in $(git branch -r | grep -E -o '^release/\d{4}$'); do
+    for branch in $(git branch -r | grep -E -o 'release/\d{4}$'); do
         open_and_merge_pull_request "${branch}";
     done
     # create PRs from master => hotfix branches

--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -98,7 +98,7 @@ if [ "${GITHUB_REF}" == "refs/heads/master" ]; then
     # create PR from master => develop
     open_and_merge_pull_request develop;
     # create PRs from master => release branches
-    for branch in $(git branch -r | grep -E -o 'release/\d{4}$'); do
+    for branch in $(git branch -r | grep -E -o 'origin/release/\d{4}$'); do
         open_and_merge_pull_request "${branch}";
     done
     # create PRs from master => hotfix branches


### PR DESCRIPTION
fix release regex which broke the branch grep, (`git branch -r` branch output starts with origin/)