### PR TITLE
Change how the script splits the list of PR information

### DIFF
--- a/automerge/entrypoint.sh
+++ b/automerge/entrypoint.sh
@@ -101,8 +101,10 @@ do
   #case insensitive compare by using the ,, to lower case
   if [ "${label,,}" = "'${MERGE_LABEL,,}'" ] # Notice the single quotes around MERGE_LABEL
   then
+    echo "Merging PR: $url into $base"
     merge_pull_request "$base" "$url"
   else
     echo "DEBUG: PR ignored from $url no matching label ($label)"
   fi
+echo ""
 done <<< "$pull_request_list"


### PR DESCRIPTION
This PR updates the shell logic in grabbing the PRs and parsing all the necessary information. This was previously broken when a label came in with spaces in it, i.e. 'do not merge'. This would subsequently break the indexing that was previously in place.

The example output from the change would show up as follows in the Actions summary:
```
DEBUG: PR - ''|https://github.com/OpenSesame/Angular/pull/3176|release/0120
DEBUG: Label - ''
DEBUG: URL - https://github.com/OpenSesame/Angular/pull/3176
DEBUG: Base - release/0120
DEBUG: PR ignored from https://github.com/OpenSesame/Angular/pull/3176 no matching label ('')

DEBUG: PR - 'automerge'|https://github.com/OpenSesame/Angular/pull/3174|develop
DEBUG: Label - 'automerge'
DEBUG: URL - https://github.com/OpenSesame/Angular/pull/3174
DEBUG: Base - develop
Merging PR: https://github.com/OpenSesame/Angular/pull/3174 into develop

DEBUG: PR - 'do not merge'|https://github.com/OpenSesame/Angular/pull/3144|feature/FTB-470_install_prettier
DEBUG: Label - 'do not merge'
DEBUG: URL - https://github.com/OpenSesame/Angular/pull/3144
DEBUG: Base - feature/FTB-470_install_prettier
DEBUG: PR ignored from https://github.com/OpenSesame/Angular/pull/3144 no matching label ('do not merge')

DEBUG: PR - 'work in progress'|https://github.com/OpenSesame/Angular/pull/3140|develop
DEBUG: Label - 'work in progress'
DEBUG: URL - https://github.com/OpenSesame/Angular/pull/3140
DEBUG: Base - develop
DEBUG: PR ignored from https://github.com/OpenSesame/Angular/pull/3140 no matching label ('work in progress')
```