### PR TITLE
FE-197 add merges for branch main

### DIFF
--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -102,9 +102,37 @@ if [ "${GITHUB_REF}" == "refs/heads/master" ]; then
     for branch in $(git branch -r | grep -E -o 'release/[0-9]{4}$'); do
         open_and_merge_pull_request "${branch}";
     done
-    
+
     # create PRs from master => hotfix branches
     for branch in $(git branch -r | grep -o 'hotfix/.*'); do
+        open_and_merge_pull_request "${branch}";
+    done
+fi
+
+# if we're on main
+if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
+    # create PR from main => develop
+    if [[ -n "$(git ls-remote origin "develop")" ]]; then
+        open_and_merge_pull_request develop;
+    fi
+
+    # create PR from main => next
+    if [[ -n "$(git ls-remote origin "next")" ]]; then
+        open_and_merge_pull_request next;
+    fi
+
+    # create PRs from main => release branches
+    for branch in $(git branch -r | grep -E -o 'release/[0-9]{4}$'); do
+        open_and_merge_pull_request "${branch}";
+    done
+
+    # create PRs from main => hotfix branches
+    for branch in $(git branch -r | grep -o 'hotfix/.*'); do
+        open_and_merge_pull_request "${branch}";
+    done
+
+    # create PRs from main => patch branches
+    for branch in $(git branch -r | grep -o 'patch/.*'); do
         open_and_merge_pull_request "${branch}";
     done
 fi


### PR DESCRIPTION
Add a condition to `merge` for branch main. For Gemini to make use of this action, the branches of the repo should be recognized. Gemini uses branch `main` as default along with the branches `next` and `patch` instead of `develop` and `hotfix`. The new condition recognizes and checks for all the branches.

I added branch `main` as its own condition with the idea that, eventually, we will move all repos away from `master` to `main`. The condition for branch `master` is then easily ignored or removed.