### PR TITLE
bugfix/CORE-1435 register github workspace as safe directory

### DIFF
--- a/automerge/entrypoint.sh
+++ b/automerge/entrypoint.sh
@@ -48,6 +48,9 @@ if [[ -z "${MERGE_LABEL}" ]]; then
     exit 1
 fi
 
+# the github workspace needs to be registered as a safe directory
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 # actions/checkout step has to be run beforehand
 # this dir is mounted into the container
 cd "${GITHUB_WORKSPACE}"

--- a/create-release-pr/entrypoint.sh
+++ b/create-release-pr/entrypoint.sh
@@ -46,6 +46,9 @@ if [[ -z "${GITHUB_TOKEN}" ]]; then
     exit 1
 fi
 
+# the github workspace needs to be registered as a safe directory
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 # actions/checkout step has to be run beforehand
 # this dir is mounted into the container
 cd "${GITHUB_WORKSPACE}"

--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -44,6 +44,9 @@ if [[ -z "${GITHUB_TOKEN}" ]]; then
     exit 1
 fi
 
+# the github workspace needs to be registered as a safe directory
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 # actions/checkout step has to be run beforehand
 # this dir is mounted into the container
 cd "${GITHUB_WORKSPACE}"


### PR DESCRIPTION
# Description
Register github workspace as a safe directory, needed with after git v2.35.2 to address CVE-2022-24765

https://github.blog/2022-04-12-git-security-vulnerability-announced/

Affects these actions:
* automerge
* create-release-pr
* merge