### PR TITLE
Removes push to branch after merge

### DIFF
--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -88,10 +88,6 @@ function open_and_merge_pull_request() {
             hub merge "${PR_URL}" && \
             echo "DEBUG: successfully merged ${GITHUB_REF} into $1" || \
             echo "DEBUG: merging ${GITHUB_REF} into $1 failed"
-            # pushes merge commit
-            git push origin "${1}" && \
-            echo "DEBUG: successfully pushed ${GITHUB_REF} merged into $1" || \
-            echo "DEBUG: pushing ${GITHUB_REF} merged into $1 failed"
         fi
     )
 }


### PR DESCRIPTION
removes pushing to the branch after the PR is merged. The PR merge will [trigger the push event](https://github.com/orgs/community/discussions/26558#discussioncomment-3252329), which our repos are configured to run the backmerge on. Angular example:
```
name: merge changes into downstream branches

on:
  push:
    branches:
      - 'master'
      - 'release/*'
      - 'develop'

jobs:
  merge:
    runs-on: ubuntu-latest
    steps:
    # checks out out repo to $GITHUB_WORKSPACE
    # note: this has to be a full clone to avoid "fatal: refusing to merge unrelated histories"
    - uses: actions/checkout@v1
    - uses: opensesame/Actions/merge@master
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
```

trying to push to develop is failing for repos that have `develop` as a protected branch. Then when the action tries to create a `master->release/0000` backmerge, [this fails](https://github.com/OpenSesame/Angular/actions/runs/5316484794/jobs/9626062796)