### PR TITLE
fix: automerge dies when encounters local changes not on remote

### DIFF
--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -99,6 +99,9 @@ function open_and_merge_pull_request() {
             # pushes merge commit
             if ! git push origin "${1}"; then
                 echo "DEBUG: pushing ${GITHUB_REF} merged into $1 failed"
+                echo "DEBUG: reverting back to origin/${1} so subsequent"
+                echo "DEBUG: steps can work with a clean working tree"
+                git reset --hard "origin/${1}"
                 return 1
             fi
 


### PR DESCRIPTION
if the push of a backmerge fails then the local working copy was left with commits on the current branch ahead of origin

we are now capturing that as an error and moving on to try the next backmerge; however that fails now because there is no clean working copy.

this commit should reset the failed merge back to match origin and leave the working copy in a better state to try the next backmerge

MP-1092