### PR TITLE
short circuit if there is no change between source and destination branch

### DIFF
--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -61,20 +61,21 @@ failures=()
 
 function open_and_merge_pull_request() {
     local source_branch="${GITHUB_REF#refs/heads/}"
-    local ahead_count
 
     echo "DEBUG: making pull request from ${GITHUB_REF} to $1"
 
     # if destination branch does not exist on origin
     if [[ -z "$(git ls-remote origin "$1")" ]]; then
         echo "Could not find expected branch '$1' on remote 'origin'"
+        return 1
     fi
 
     # Skip no-op merges so identical branches do not fail PR creation with
     # "No commits between ..." validation errors.
-    ahead_count="$(git rev-list --count "origin/$1..origin/${source_branch}")"
+    local ahead_commit
+    ahead_commit="$(git rev-list --max-count=1 "origin/$1..origin/${source_branch}")"
 
-    if [[ "${ahead_count}" == "0" ]]; then
+    if [[ -z "${ahead_commit}" ]]; then
         echo "DEBUG: skipping merge of ${GITHUB_REF} into $1; ${source_branch} has no commits ahead of $1"
         return 0
     fi

--- a/merge/entrypoint.sh
+++ b/merge/entrypoint.sh
@@ -60,11 +60,23 @@ git remote prune origin
 failures=()
 
 function open_and_merge_pull_request() {
+    local source_branch="${GITHUB_REF#refs/heads/}"
+    local ahead_count
+
     echo "DEBUG: making pull request from ${GITHUB_REF} to $1"
 
-    # if $1 branch does not exist origin
+    # if destination branch does not exist on origin
     if [[ -z "$(git ls-remote origin "$1")" ]]; then
         echo "Could not find expected branch '$1' on remote 'origin'"
+    fi
+
+    # Skip no-op merges so identical branches do not fail PR creation with
+    # "No commits between ..." validation errors.
+    ahead_count="$(git rev-list --count "origin/$1..origin/${source_branch}")"
+
+    if [[ "${ahead_count}" == "0" ]]; then
+        echo "DEBUG: skipping merge of ${GITHUB_REF} into $1; ${source_branch} has no commits ahead of $1"
+        return 0
     fi
 
     # subshell with +e so we continue on errors


### PR DESCRIPTION
There is a bug in the "merge" Github Action causing it to fail when there is no difference between the source branch and destination branch. See this GHA output for reference: https://github.com/OpenSesame/Catalog/actions/runs/24209438648/job/72192345956?pr=17939

```
{"base":"develop","head":"OpenSesame:refs/heads/release/0000","maintainer_can_modify":true,"title":"Automated Merge"}
< HTTP 422
{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"No commits between develop and release/0000"}],"documentation_url":"https://docs.github.com/rest/pulls/pulls#create-a-pull-request","status":"422"}
Error creating pull request: Unprocessable Entity (HTTP 422)
No commits between develop and release/0000
Failed to get PR URL for merge of refs/heads/release/0000 into develop
One or more merges failed:
 - develop
 ```

Because there are no commits between the source and destination, it fails to create a PR to merge downstream changes.

This PR fixes that issue by short circuiting when source and destination are the same.